### PR TITLE
Set Pathlimit to default maxFieldString if the length is lower

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/gocsi
 
-go 1.17
+go 1.18
 
 require (
 	github.com/akutz/gosync v0.1.0

--- a/middleware/specvalidator/spec_validator.go
+++ b/middleware/specvalidator/spec_validator.go
@@ -849,6 +849,11 @@ func setPathLimit(defaultValue int) int {
 	if found && maxPathLimitStr != "" {
 		maxPathLimit, err := strconv.Atoi(maxPathLimitStr)
 		if err == nil {
+			if maxPathLimit < 0 {
+				maxPathLimit = pathLimit
+				log.Debug("PathLimit: ", maxPathLimit)
+				return maxPathLimit
+			}
 			log.Debug("PathLimit: ", maxPathLimit)
 			return maxPathLimit
 		}

--- a/middleware/specvalidator/spec_validator.go
+++ b/middleware/specvalidator/spec_validator.go
@@ -849,9 +849,9 @@ func setPathLimit(defaultValue int) int {
 	if found && maxPathLimitStr != "" {
 		maxPathLimit, err := strconv.Atoi(maxPathLimitStr)
 		if err == nil {
-			if maxPathLimit < 0 {
+			if maxPathLimit < pathLimit {
 				maxPathLimit = pathLimit
-				log.Debug("PathLimit set to negative value, using the default value for pathLimit: ", maxPathLimit)
+				log.Debug("PathLimit set is less than the default value, using the default value for pathLimit: ", maxPathLimit)
 				return maxPathLimit
 			}
 			log.Debug("PathLimit: ", maxPathLimit)

--- a/middleware/specvalidator/spec_validator.go
+++ b/middleware/specvalidator/spec_validator.go
@@ -851,7 +851,7 @@ func setPathLimit(defaultValue int) int {
 		if err == nil {
 			if maxPathLimit < 0 {
 				maxPathLimit = pathLimit
-				log.Debug("PathLimit: ", maxPathLimit)
+				log.Debug("PathLimit set to negative value, using the default value for pathLimit: ", maxPathLimit)
 				return maxPathLimit
 			}
 			log.Debug("PathLimit: ", maxPathLimit)

--- a/middleware/specvalidator/specvalidator_envvars.go
+++ b/middleware/specvalidator/specvalidator_envvars.go
@@ -3,6 +3,6 @@ package specvalidator
 const (
 	// EnvVarMaxPathLimit is the name of the environment
 	// variable that defines the maximum path length.
-	// If not set, it defaults to 128
+	// If not set, it defaults to 192
 	EnvVarMaxPathLimit = "X_CSI_MAX_PATH_LIMIT"
 )

--- a/middleware/specvalidator/specvalidator_envvars.go
+++ b/middleware/specvalidator/specvalidator_envvars.go
@@ -3,6 +3,6 @@ package specvalidator
 const (
 	// EnvVarMaxPathLimit is the name of the environment
 	// variable that defines the maximum path length.
-	// If not set, it defaults to 192
+	// If not set, it defaults to maxFieldString
 	EnvVarMaxPathLimit = "X_CSI_MAX_PATH_LIMIT"
 )


### PR DESCRIPTION
# Description
This PR is used to check the values that is configured in values yaml for the path limit feature.
The custom value supplied needs to be greater than maxFieldString which is 192 characters.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/263 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

-  Set the negative value(-10) in the values.yaml file of csi-powerscale and verified that the maxPathLimit parameter was taking the default value in the driver logs
time="2022-05-25T13:39:10Z" level=debug msg="PathLimit set to negative value, using the default value for pathLimit: 192"
- Set the maxPathLimit to 30 in the values.yaml file and verified that the  maxPathLimit parameter was taking the value set in the file in the driver logs.
time="2022-05-25T13:41:34Z" level=debug msg="PathLimit: 30"
