### PR TITLE
Fix: Revert Changes to Socket Exist Check

### DIFF
--- a/gocsi.go
+++ b/gocsi.go
@@ -103,7 +103,7 @@ func Run(
 
 	l, err := utils.GetCSIEndpointListener()
 	if err != nil {
-		log.WithError(err).Info("failed to listen")
+		log.WithError(err).Fatalln("failed to listen")
 		osExit(1)
 	}
 
@@ -128,6 +128,10 @@ func Run(
 		sp.GracefulStop(ctx)
 		rmSockFile()
 		log.Info("server stopped gracefully")
+	}, func() {
+		sp.Stop(ctx)
+		rmSockFile()
+		log.Info("server aborted")
 	})
 
 	if err := sp.Serve(ctx, l); err != nil {
@@ -492,7 +496,22 @@ func (sp *StoragePlugin) getEnvBool(ctx context.Context, key string) bool {
 	return false
 }
 
-func trapSignals(onExit func()) {
+// isExitSignal returns a flag indicating whether a signal SIGHUP,
+// SIGINT, SIGTERM, or SIGQUIT. The second return value is whether it is a
+// graceful exit. This flag is true for SIGTERM, SIGHUP, SIGINT, and SIGQUIT.
+func isExitSignal(s os.Signal) (bool, bool) {
+	switch s {
+	case syscall.SIGTERM,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT:
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+func trapSignals(onExit, onAbort func()) {
 	sigc := make(chan os.Signal, 1)
 	sigs := []os.Signal{
 		syscall.SIGTERM,
@@ -503,6 +522,18 @@ func trapSignals(onExit func()) {
 	signal.Notify(sigc, sigs...)
 	go func() {
 		for s := range sigc {
+			ok, graceful := isExitSignal(s)
+			if !ok {
+				continue
+			}
+			if !graceful {
+				log.WithField("signal", s).Error("received signal; aborting")
+				if onAbort != nil {
+					onAbort()
+				}
+				os.Exit(1)
+			}
+
 			log.WithField("signal", s).Info("received signal; shutting down")
 			if onExit != nil {
 				onExit()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -81,6 +81,8 @@ func ParseProtoAddr(protoAddr string) (proto string, addr string, err error) {
 		return "", "", ErrParseProtoAddrRequired
 	}
 
+	log.Infof("[Fernando] We are processing %s", protoAddr)
+
 	// If the provided network address does not begin with one
 	// of the valid network protocols then treat the string as a
 	// file path.
@@ -95,7 +97,7 @@ func ParseProtoAddr(protoAddr string) (proto string, addr string, err error) {
 
 		// If the file already exists then assume it's a valid sock
 		// file and return it.
-		if _, err := os.Stat(protoAddr); os.IsExist(err) {
+		if _, err := os.Stat(protoAddr); !os.IsNotExist(err) {
 			return "unix", protoAddr, nil
 		}
 		f, err := os.Create(filepath.Clean(protoAddr))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -81,8 +81,6 @@ func ParseProtoAddr(protoAddr string) (proto string, addr string, err error) {
 		return "", "", ErrParseProtoAddrRequired
 	}
 
-	log.Infof("[Fernando] We are processing %s", protoAddr)
-
 	// If the provided network address does not begin with one
 	// of the valid network protocols then treat the string as a
 	// file path.
@@ -94,7 +92,6 @@ func ParseProtoAddr(protoAddr string) (proto string, addr string, err error) {
 	// without error then remove the file and return the result a UNIX
 	// socket file path.
 	if !protoAddrGuessRX.MatchString(protoAddr) {
-
 		// If the file already exists then assume it's a valid sock
 		// file and return it.
 		if _, err := os.Stat(protoAddr); !os.IsNotExist(err) {


### PR DESCRIPTION
# Description
After various scale testing, it was identified that removing of the socket was not properly occurring. It is a common misconception that `Stat` returns of opposite if the file exists for the error, but that is not the case. A common practice is to negate the `NotExist` check for checking a files existence.

**Reference:**
- https://gist.github.com/mattes/d13e273314c3b3ade33f
- https://www.tutorialspoint.com/how-to-check-if-a-file-exists-in-golang

After reverting this change, upon a CLBO, the controller pods recover as expected.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure that all tests run.
- [x] Run a scale test that causes the controller pod to crash and ensure that the tests succeed.